### PR TITLE
add namedtuple(Vector{Pair{Symbol}}

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -197,5 +197,6 @@ function Base.Dict(nt::NT) where {N,T,NT<:NamedTuple{N,T}}
     return Dict(z)
 end
 
+namedtuple(v::Vector{<:Pair{<:Symbol}}) = namedtuple([p[1] for p in v]...)([p[2] for p in v]...)
 
 end # module NamedTupleTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,3 +41,7 @@ dict = Dict(:a=>1, :b=>2//11, :c=>"three")
 nt = NamedTuple(dict)
 
 @test Dict(nt) == dict
+
+vec_pair = [:a => 1, :b => 2]
+nt = (a = 1, b = 2)
+@test namedtuple(vec_pair) == nt


### PR DESCRIPTION
This PR allows for the following 

```
v = [:a => 1, :b => 2]
namedtuple(v)
```

It's use was motivated by stuff in DataFrames that might eventually have both `Pair` and `NamedTuple` arguments that do similar things. 