### PR TITLE
add `select`

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -244,6 +244,19 @@ delete(::Type{T}, b::NTuple{N,Symbol}) where {S,N,T<:NamedTuple{S}} = namedtuple
 delete(::Type{T}, bs::Vararg{Symbol}) where {S,N,T<:NamedTuple{S}} = namedtuple((Base.setdiff(S,bs)...,))
 
 """
+   select(namedtuple, symbol(s)|Tuple)
+   select(ntprototype, symbol(s)|Tuple)
+   
+Generate a namedtuple [ntprototype] from the first arg, including only fields present in the second arg.
+
+see: [`merge`](@ref)
+"""
+select(nt::NamedTuple, k::Symbol) = nt[k]
+select(nt::NamedTuple, k::NamedTuple) = select(nt, keys(k))
+select(nt::NamedTuple, ks) = namedtuple(ks)((nt[k] for k in ks)...)
+
+
+"""
     merge(namedtuple1, namedtuple2)
     merge(nt1, nt2, nt3, ..)
 

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -13,6 +13,7 @@ export @namedtuple,
        namedtuple, isprototype,
        fieldvalues,
        delete,
+       select,
        ntfromstruct, structfromnt,
        @structfromnt
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,10 @@ nt2 = ntproto2("one", "two")
 
 @test merge(nt1, nt2) === (a = "one", b  = "two", c = 3, d = 4)
 
+@test select(nt1, :a) == nt1[:a]
+@test select(nt1, nt2) == (a=1,b=2)
+@test select(nt1, nt2) == select(nt1, keys(nt2))
+
 struct MyStruct
     tally::Int
     team::String


### PR DESCRIPTION
This is a small addition to make it easy build a new `NamedTuple` with a subset of the original keys:
```julia
select(nt::NamedTuple, k::Symbol) = nt[k]
select(nt::NamedTuple, k::NamedTuple) = select(nt, keys(k))
select(nt::NamedTuple, ks) = namedtuple(ks)((nt[k] for k in ks)...)
```

See https://github.com/JeffreySarnoff/NamedTupleTools.jl/issues/7#issuecomment-518396085