### PR TITLE
Support "named arguments" and splatting in at-namedtuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ julia> nt = namedtuple(vec)
 (a = 1, b = 2)
 ```
 
-##  Defined Variables (Sebastian Pfitzner)
+##  Defined variables mixed with standard syntax (Sebastian Pfitzner, Takafumi Arakaki)
 ```julia
 julia> a, b, c, d, f = 1, 1.0, 1//1, "one", (g=1,)
 (1, 1.0, 1//1, "one", (g = 1,))

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ julia> nt = namedtuple(vec)
 
 ##  Defined Variables (Sebastian Pfitzner)
 ```julia
-julia> a, b, c, d = 1, 1.0, 1//1, "one"
-(1, 1.0, 1//1, "one")
-julia> nt = @namedtuple(a, b, c, d)
-(a = 1, b = 1.0, c = 1//1, d = "one")
+julia> a, b, c, d, f = 1, 1.0, 1//1, "one", (g=1,)
+(1, 1.0, 1//1, "one", (g = 1,))
 
+julia> nt = @namedtuple(a, b, c, d, e = a + b, f...)
+(a = 1, b = 1.0, c = 1//1, d = "one", e = 2.0, g = 1)
 ```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ julia> nt = namedtuple(vec)
 (a = 1, b = 2)
 ```
 
-##  Defined variables mixed with standard syntax (Sebastian Pfitzner, Takafumi Arakaki)
+## Variables mixed with standard syntax (Sebastian Pfitzner, Takafumi Arakaki)
 ```julia
 julia> a, b, c, d, f = 1, 1.0, 1//1, "one", (g=1,)
 (1, 1.0, 1//1, "one", (g = 1,))

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -330,10 +330,14 @@ namedtuple(v::Vector{<:Pair{<:String}}) = namedtuple([p[1] for p in v]...)([p[2]
 # from Sebastian Pfitzner (on Slack)
 macro namedtuple(vars...)
    args = Any[]
-   for i in 1:length(vars)
-       push!(args, Expr(:(=), esc(vars[i]), :($(esc(vars[i])))))
+   for v in vars
+       if Meta.isexpr(v, :(=)) || Meta.isexpr(v, :...)
+           push!(args, esc(v))
+       else
+           push!(args, Expr(:(=), esc(v), esc(v)))
+       end
    end
-   expr = Expr(:tuple, args...)
+   expr = Expr(:tuple, Expr(:parameters, args...))
    return expr
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,3 +99,11 @@ nt = (a = 1, b = 2)
 a = 1; b = 2;
 nt_ab = @namedtuple(a, b)
 @test nt_ab == nt
+
+nt = (a = 1, b = 2, c = 3)
+@test @namedtuple(a, b, c = 3) == nt
+
+nt1 = (a = 1, b = 2)
+c = 3
+nt = (a = 1, b = 2, c = 3)
+@test @namedtuple(nt1..., c) == nt


### PR DESCRIPTION
This PR implements keyword arguments and splatting for `@namedtuple`:

```julia
julia> a = 1
       nt = @namedtuple(a, b = 2)
(a = 1, b = 2)

julia> c = 3
       @namedtuple(nt..., c)
(a = 1, b = 2, c = 3)
```
