### PR TITLE
Add split function

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -256,7 +256,7 @@ see: [`merge`](@ref)
 """
 select(nt::NamedTuple, k::Symbol) = nt[k]
 select(nt::NamedTuple, k::NamedTuple) = select(nt, keys(k))
-select(nt::NamedTuple, ks) = namedtuple(ks)((nt[k] for k in ks)...)
+select(nt::NamedTuple, ks) = namedtuple(ks)(((nt[k] for k in ks)...,))
 
 
 """

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -13,12 +13,13 @@ export @namedtuple,
        namedtuple, isprototype,
        propertynames, fieldnames, fieldvalues, fieldtypes,
        merge,
+       split,
        delete,
        select,
        ntfromstruct, structfromnt,
        @structfromnt
 
-import Base: propertynames, fieldnames, valtype, values, merge
+import Base: propertynames, fieldnames, valtype, values, merge, split
 
 if isdefined(Base, :fieldtypes)
      import Base: fieldtypes
@@ -293,6 +294,16 @@ merge(a::NamedTuple{an}, b::NamedTuple{bn}, c::NamedTuple{cn}, d::NamedTuple{dn}
     reduce(merge,(a, b, c, d, e, f))
 merge(a::NamedTuple{an}, b::NamedTuple{bn}, c::NamedTuple{cn}, d::NamedTuple{dn}, e::NamedTuple{en}, f::NamedTuple{fn}, g::NamedTuple{gn}) where {an, bn, cn, dn, en, fn, gn} =
     reduce(merge,(a, b, c, d, e, f, g))
+
+"""
+    split(namedtuple, symbol(s)|Tuple)
+
+Generate two namedtuples, the first with only the fields in the second arg, the
+second with all but the fields in the second arg, such that
+`merge(split(nt, ks)...) == nt` when `ks` contains the first fields of `nt`.
+"""
+split(nt::NamedTuple, ks::Symbol) = split(nt, (ks,))
+split(nt::NamedTuple, ks) = select(nt, ks), delete(nt, ks)
 
 
 #=  interconvert: NamedTuple <--> Dict =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ nt2 = ntproto2("one", "two")
 @test select(nt1, :a) == nt1[:a]
 @test select(nt1, nt2) == (a=1,b=2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
+@test select((a = 1, b = [1, 2]), (:b,)) == (b = [1, 2],)
 
 @test split(nt1, :a)[1] == (a = 1,)
 @test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,12 @@ nt2 = ntproto2("one", "two")
 @test select(nt1, nt2) == (a=1,b=2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
 
+@test split(nt1, :a)[1] == (a = 1,)
+@test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)
+@test split(nt1, (:b, :c))[1] == (b = 2, c = 3)
+@test split(nt1, (:b, :c))[2] == (a = 1, d = 4)
+@test merge(split(nt1, (:a, :b))...) == nt1
+
 struct MyStruct
     tally::Int
     team::String


### PR DESCRIPTION
This PR extends `Base.split` to accompany `Base.merge`. Example usage:

```julia
julia> using NamedTupleTools

julia> nt = (a = 1, b = 2, c = 3, d = 4)
(a = 1, b = 2, c = 3, d = 4)

julia> split(nt, :a)
((a = 1,), (b = 2, c = 3, d = 4))

julia> split(nt, (:a, :b))
((a = 1, b = 2), (c = 3, d = 4))

julia> merge(split(nt, (:a, :b))...) == nt
true
```

It also fixes a bug in `select`.