### PR TITLE
Tighten types on conversion from Dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ git:
   depth: 99999999  
 notifications:
   email: false
+before_script:
+  - julia -e 'if VERSION < v"1.3"; import Pkg; Pkg.add("OrderedCollections"); end'
 #script: # the default script is equivalent to the following
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
-authors = ["Jeffrey Sarnoff <jeffrey.sarnoff@gmail.com>"]
 name = "NamedTupleTools"
 uuid = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 license = "MIT"
+authors = ["Jeffrey Sarnoff <jeffrey.sarnoff@gmail.com>"]
 version = "0.12.1"
+
+[compat]
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1"

--- a/README.md
+++ b/README.md
@@ -220,12 +220,12 @@ julia> mystruct == ntstruct
 true
 ```
 
-## Dict construction, reconstruction 
+## AbstractDict construction, reconstruction 
 ```julia
 julia> adict = Dict(:a => 1, :b => "two")
 Dict{String,Int} with 3 entries:
   :a => 1
-  :b => 2
+  :b => "two"
 
 julia> nt = namedtuple(adict)
 (a = 1, b = "two")
@@ -241,6 +241,21 @@ julia> nt = namedtuple(adict)
 
 julia> convert(Dict, nt) == adict
 true
+
+julia> using OrderedCollections: OrderedDict, LittleDict
+
+julia> ldict = OrderedDict(:a => 1, :b => "two")
+OrderedDict{Symbol,Any} with 2 entries:
+  :a => 1
+  :b => "two"
+
+julia> nt = namedtuple(ldict)
+(a = 1, b = "two")
+
+julia> convert(LittleDict, nt)
+LittleDict{Symbol,Union{Int64, String},Array{Symbol,1},Array{Union{Int64, String},1}} with 2 entries:
+  :a => 1
+  :b => "two"
 ```
 
 ## Vector of Pairs (Peter Deffebach)

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -317,9 +317,9 @@ Collect the elements of x into a Tuple, in their iterated order.
 """
 @inline gather_(x::T) where {T} = (collect(x)...,)
 
-namedtuple(d::T) where {T<:Dict{Symbol,V}} where {V} =
+namedtuple(d::T) where {T<:AbstractDict{Symbol,V}} where {V} =
     NamedTuple{gather_(keys(d)), NTuple{length(d), V}}(gather_(values(d)))
-namedtuple(d::T) where {T<:Dict{S,V}} where {S<:AbstractString, V} =
+namedtuple(d::T) where {T<:AbstractDict{S,V}} where {S<:AbstractString, V} =
     NamedTuple{Symbol.(gather_(keys(d))), NTuple{length(d), V}}(gather_(values(d)))
 
 # use: dict = convert(Dict, nt)
@@ -328,8 +328,8 @@ namedtuple(d::T) where {T<:Dict{S,V}} where {S<:AbstractString, V} =
    Base.convert(::Type{Dict}, x::NT) where {N, NT<:NamedTuple{N}} = 
        Dict([sym=>val for (sym,val) in zip(fieldnames(x), fieldvalues(x))])
 =#
-Base.convert(::Type{Dict}, x::NT) where {N, NT<:NamedTuple{N}} = 
-    Dict{Symbol, uniontype(x)}([sym=>val for (sym,val) in zip(fieldnames(x), fieldvalues(x))])
+Base.convert(::Type{D}, x::NT) where {D<:AbstractDict, N, NT<:NamedTuple{N}} = 
+    D{Symbol, uniontype(x)}([sym=>val for (sym,val) in zip(fieldnames(x), fieldvalues(x))])
 
 dictionary(nt::NamedTuple) = convert(Dict, nt) # deprecated
 

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -321,6 +321,10 @@ namedtuple(d::T) where {T<:AbstractDict{Symbol,V}} where {V} =
     NamedTuple{gather_(keys(d)), NTuple{length(d), V}}(gather_(values(d)))
 namedtuple(d::T) where {T<:AbstractDict{S,V}} where {S<:AbstractString, V} =
     NamedTuple{Symbol.(gather_(keys(d))), NTuple{length(d), V}}(gather_(values(d)))
+namedtuple(d::T) where {T<:AbstractDict{Symbol,Any}} =
+    NamedTuple{gather_(keys(d)), Tuple{typeof.(values(d))...}}(gather_(values(d)))
+namedtuple(d::T) where {T<:AbstractDict{S,Any}} where {S<:AbstractString} =
+    NamedTuple{Symbol.(gather_(keys(d))), Tuple{typeof.(values(d))...}}(gather_(values(d)))
 
 # use: dict = convert(Dict, nt)
 #=

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using NamedTupleTools
 using Test
+using OrderedCollections: OrderedDict, LittleDict
 
 namesofvalues  = (:instrument, :madeby)
 matchingvalues = ("violin", "Stradivarius")
@@ -92,15 +93,24 @@ v = [:b => 2, :a => 1]
 v = ["b" => 2, "a" => 1]
 @test namedtuple(v) == NamedTuple{(:b, :a)}(2, 1)
 
-dict1 = Dict(:a=>1)
-nt1 = (a = 1,)
-dict3 = Dict(:a=>1, :b=>2//11, :c=>"three")
-nt3 = (a = 1, b = 2//11, c = "three")
+for DictType in [Dict, OrderedDict, LittleDict]
+    let DT=DictType
+        dict1 = DT(:a=>1)
+        nt1 = (a = 1,)
+        dict2 = DT(:a=>1, :b=>2//11, :c=>"three")
+        nt2 = (a = 1, b = 2//11, c = "three")
 
-@test convert(Dict, nt1) == dict1
-@test namedtuple(dict1) == nt1
-@test convert(Dict, nt3) == dict3
-@test namedtuple(dict3) == nt3
+        nt1_to_dict = convert(DT, nt1)
+        @test nt1_to_dict == dict1
+        @test nt1_to_dict isa DT
+        @test namedtuple(dict1) == nt1
+    
+        nt2_to_dict = convert(DT, nt2)
+        @test nt2_to_dict == dict2
+        @test nt2_to_dict isa DT
+        @test namedtuple(dict2) == nt2
+    end
+end
 
 nt = (a = 1, b = 2)
 a = 1; b = 2;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,16 @@ for DictType in [Dict, OrderedDict, LittleDict]
     end
 end
 
+# Note: checking the types below requires an ordered dictionary
+dict1 = LittleDict(:a=>1, :b=>2//11, :c=>"three")
+nt1 = namedtuple(dict1)
+@test nt1 isa NamedTuple{(:a, :b, :c),Tuple{Int64,Rational{Int64},String}}
+
+dict2 = LittleDict("a"=>1, "b"=>2//11, "c"=>"three")
+nt2 = namedtuple(dict2)
+@test nt2 isa NamedTuple{(:a, :b, :c),Tuple{Int64,Rational{Int64},String}}
+
+
 nt = (a = 1, b = 2)
 a = 1; b = 2;
 nt_ab = @namedtuple(a, b)


### PR DESCRIPTION
Previously:

```julia
julia> adict = Dict(:a => 1, :b => 2//11, :c => "three")
Dict{Symbol,Any} with 3 entries:
  :a => 1
  :b => 2//11
  :c => "three"

julia> namedtuple(adict)
NamedTuple{(:a, :b, :c),Tuple{Any,Any,Any}}((1, 2//11, "three"))
```

With this PR:
```julia
julia> nt = namedtuple(adict)
(a = 1, b = 2//11, c = "three")

julia> typeof(nt)
NamedTuple{(:a, :b, :c),Tuple{Int64,Rational{Int64},String}}
```

Note that this currently includes (and depends on) #16, but I wanted to separate it out in case this wasn't desired for some reason.