### PR TITLE
Fix deprecate call

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -363,8 +363,6 @@ macro namedtuple(vars...)
 end
 
 
-@eval Base begin
-    @deprecate namedtuple(nt::$NamedTuple) $prototype(nt::$NamedTuple)
-end
+Base.@deprecate namedtuple(nt::NamedTuple) prototype(nt::NamedTuple)
 
 end # module NamedTupleTools


### PR DESCRIPTION
This PR fixes the precompilation warning:

```
julia> using NamedTupleTools
[ Info: Precompiling NamedTupleTools [d9ec5142-1e00-5aa0-9d6a-321866360f50]
WARNING: eval into closed module Base:
Expr(:block, #= Symbol("/home/takafumi/.julia/dev/NamedTupleTools/src/NamedTupleTools.jl"):367 =#, Expr(:macrocall, Symbol("@deprecate"), #= Symbol("/home/takafumi/.julia/dev/NamedTupleTools/src/NamedTupleTools.jl"):367 =#, Expr(:call, :namedtuple, Expr(:::, :nt, NamedTuple{names, T} where T<:Tuple where names)), Expr(:call, typeof(NamedTupleTools.prototype)(), Expr(:::, :nt, NamedTuple{names, T} where T<:Tuple where names))))
  ** incremental compilation may be fatally broken for this module **
```
