### PR TITLE
Infer select

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -41,7 +41,7 @@ obtain values assigned to fields of a struct type
 """
 function fieldvalues(x::T) where {T}
      !isstructtype(T) && throw(ArgumentError("$(T) is not a struct type"))
-     
+
      return ((getfield(x, name) for name in fieldnames(T))...,)
 end
 
@@ -124,8 +124,8 @@ macro structfromnt(sname, nt)
     :( eval(structfromnt($(esc(sname)), $(esc(nt)))) )
 end
 
-# Expr part from Fredrik Ekre   
-struct_from(structname, names, types) = 
+# Expr part from Fredrik Ekre
+struct_from(structname, names, types) =
 	"Expr(:struct,
 		false,
 		Expr(:curly,
@@ -135,7 +135,7 @@ struct_from(structname, names, types) =
 			map((x,y) -> Expr(:(::), x, y), $names, $types)...
 		)
 	)"
-	
+
 structfrom(structname, names, types) = eval(eval(Meta.parse(struct_from(structname, names, types))))
 
 """
@@ -236,7 +236,7 @@ isprototype(::Type{UnionAll}) = false
 """
    delete(namedtuple, symbol(s)|Tuple)
    delete(ntprototype, symbol(s)|Tuple)
-   
+
 Generate a namedtuple [ntprototype] from the first arg omitting fields present in the second arg.
 
 see: [`merge`](@ref)
@@ -311,12 +311,12 @@ split(nt::NamedTuple, ks) = select(nt, ks), delete(nt, ks)
 
 #=  interconvert: NamedTuple <--> Dict =#
 
-uniontype(nt::NamedTuple) = Union{typeof.(values(nt))...,}	
+uniontype(nt::NamedTuple) = Union{typeof.(values(nt))...,}
 
 """
     gather_(x::Iterable)
 
-Collect the elements of x into a Tuple, in their iterated order. 
+Collect the elements of x into a Tuple, in their iterated order.
 """
 @inline gather_(x::T) where {T} = (collect(x)...,)
 
@@ -331,11 +331,11 @@ namedtuple(d::T) where {T<:AbstractDict{S,Any}} where {S<:AbstractString} =
 
 # use: dict = convert(Dict, nt)
 #=
-   for Dict{Symbol,Any}: 
-   Base.convert(::Type{Dict}, x::NT) where {N, NT<:NamedTuple{N}} = 
+   for Dict{Symbol,Any}:
+   Base.convert(::Type{Dict}, x::NT) where {N, NT<:NamedTuple{N}} =
        Dict([sym=>val for (sym,val) in zip(fieldnames(x), fieldvalues(x))])
 =#
-Base.convert(::Type{D}, x::NT) where {D<:AbstractDict, N, NT<:NamedTuple{N}} = 
+Base.convert(::Type{D}, x::NT) where {D<:AbstractDict, N, NT<:NamedTuple{N}} =
     D{Symbol, uniontype(x)}([sym=>val for (sym,val) in zip(fieldnames(x), fieldvalues(x))])
 
 dictionary(nt::NamedTuple) = convert(Dict, nt) # deprecated
@@ -345,7 +345,7 @@ namedtuple(v::Vector{<:Pair{<:Symbol}}) = namedtuple([p[1] for p in v]...)([p[2]
 # with names as strings
 namedtuple(v::Vector{<:Pair{<:String}}) = namedtuple([p[1] for p in v]...)([p[2] for p in v]...)
 
-# NamedTuple becomes a Vector of Pairs 
+# NamedTuple becomes a Vector of Pairs
 Base.convert(::Type{Vector{Pair}}, nt::NamedTuple) =  map(kv->Pair(first(kv), last(kv)), zip(keys(nt), values(nt)))
 
 # from Sebastian Pfitzner (on Slack)

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -241,9 +241,9 @@ Generate a namedtuple [ntprototype] from the first arg omitting fields present i
 
 see: [`merge`](@ref)
 """
-delete(a::NamedTuple, b::Symbol) = Base.structdiff(a, namedtuple(b))
-delete(a::NamedTuple, b::NTuple{N,Symbol}) where {N} = Base.structdiff(a, namedtuple(b))
-delete(a::NamedTuple, bs::Vararg{Symbol}) = Base.structdiff(a, namedtuple(bs))
+@inline delete(a::NamedTuple, b::Symbol) = Base.structdiff(a, namedtuple(b))
+@inline delete(a::NamedTuple, b::NTuple{N,Symbol}) where {N} = Base.structdiff(a, namedtuple(b))
+@inline delete(a::NamedTuple, bs::Vararg{Symbol}) = Base.structdiff(a, namedtuple(bs))
 
 delete(::Type{T}, b::Symbol) where {S,T<:NamedTuple{S}} = namedtuple((Base.setdiff(S,(b,))...,))
 delete(::Type{T}, b::NTuple{N,Symbol}) where {S,N,T<:NamedTuple{S}} = namedtuple((Base.setdiff(S,b)...,))

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -252,14 +252,14 @@ delete(::Type{T}, bs::Vararg{Symbol}) where {S,N,T<:NamedTuple{S}} = namedtuple(
 """
    select(namedtuple, symbol(s)|Tuple)
    select(ntprototype, symbol(s)|Tuple)
-   
+
 Generate a namedtuple [ntprototype] from the first arg, including only fields present in the second arg.
 
 see: [`merge`](@ref)
 """
 select(nt::NamedTuple, k::Symbol) = nt[k]
 select(nt::NamedTuple, k::NamedTuple) = select(nt, keys(k))
-select(nt::NamedTuple, ks) = namedtuple(ks)(((nt[k] for k in ks)...,))
+@inline select(nt::NamedTuple, ks) = namedtuple(ks)(map(k->nt[k], ks))
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,8 @@ proto2 = prototype(nt2)
 @test delete(nt1, :a) == (b = 2, c = 3, d = 4)
 @test delete(nt1, :a, :c) == (b = 2, d = 4)
 @test delete(nt1, (:a, :b, :c)) === (d = 4,)
+test_delete_infer(nt) = delete(nt, (:a,))
+@inferred test_delete_infer(nt1)
 
 @test merge(nt1, nt2) === (a = "one", b  = "two", c = 3, d = 4)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,7 +111,7 @@ for DictType in [Dict, OrderedDict, LittleDict]
         @test nt1_to_dict == dict1
         @test nt1_to_dict isa DT
         @test namedtuple(dict1) == nt1
-    
+
         nt2_to_dict = convert(DT, nt2)
         @test nt2_to_dict == dict2
         @test nt2_to_dict isa DT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ proto2 = prototype(nt2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
 @test select((a = 1, b = [1, 2]), (:b,)) == (b = [1, 2],)
 test_select_infer(nt) = select(nt, (:b, :a))
-@inferred test_select_infer((a = 3, b = 4, c = 5))
+@inferred test_select_infer(nt1)
 
 @test split(nt1, :a)[1] == (a = 1,)
 @test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,8 @@ proto2 = prototype(nt2)
 @test select(nt1, nt2) == (a=1,b=2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
 @test select((a = 1, b = [1, 2]), (:b,)) == (b = [1, 2],)
+test_select_infer(nt) = select(nt, (:b, :a))
+@inferred test_select_infer((a = 3, b = 4, c = 5))
 
 @test split(nt1, :a)[1] == (a = 1,)
 @test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)


### PR DESCRIPTION
This is the interesting commit: https://github.com/JeffreySarnoff/NamedTupleTools.jl/commit/1bdfef63ecb0a4090cf4c95183cb621b2ef6991e

It seems like there are other functions that would benefit from a similar treatment, which is why I wrote #26 in general terms. Also the `@inferred` test might fail on Julia 1.0 [edit it passed].