### PR TITLE
Add `flattened`

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -18,7 +18,8 @@ export @namedtuple,
        delete,
        select,
        ntfromstruct, structfromnt,
-       @structfromnt
+       @structfromnt,
+       flattened
 
 import Base: propertynames, fieldnames, valtype, values, merge, split
 
@@ -467,5 +468,57 @@ end
 
 
 Base.@deprecate namedtuple(nt::NamedTuple) prototype(nt::NamedTuple)
+
+join_tup_chain(tup_chain, separator::Symbol) = Symbol(join(tup_chain, separator)...)
+
+function flattened!(k_all, v_all, nt, tup_chain, separator, filter_leaves, process_leaves)
+    for pn in propertynames(nt)
+        p = getproperty(nt, pn)
+        tup_chain_new = (tup_chain..., pn)
+        if filter_leaves(pn, p)
+            push!(k_all, join_tup_chain(tup_chain_new, separator))
+            push!(v_all, process_leaves(pn, p))
+        end
+        flattened!(k_all, v_all, p, tup_chain_new, separator, filter_leaves, process_leaves)
+    end
+end
+
+"""
+    flattened(nt::NamedTuple,
+              separator::Symbol = :_,
+              filter_leaves::Function = (pn,p) -> true,
+              process_leaves::Function = (pn,p) -> p)
+
+A flattened namedtuple, given a nested
+namedtuple, which also may contain Tuples
+of namedtuples.
+
+The leaves of the nested namedtuples
+can be filtered with the function argument
+`filter_leaves`, and processed with the
+function argument `process_leaves`.
+
+# Example
+```julia
+julia> nt = (x = 1, a = (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,))));
+
+julia> fnt = flattened(nt, :_);
+
+julia> keys(fnt)
+(:x, :a, :a_y, :a_z, :a_b, :a_b_1, :a_b_1_a, :a_b_2, :a_b_2_a, :a_b_3, :a_b_3_a)
+
+julia> values(fnt)
+(1, (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,))), 2, 3, ((a = 1,), (a = 2,), (a = 3,)), (a = 1,), 1, (a = 2,), 2, (a = 3,), 3)
+```
+"""
+function flattened(nt::NamedTuple,
+                   separator::Symbol = :_,
+                   filter_leaves::Function = (pn,p) -> true,
+                   process_leaves::Function = (pn,p) -> p)
+    k_all, v_all = [], []
+    tup_chain = ()
+    flattened!(k_all, v_all, nt, tup_chain, separator, filter_leaves, process_leaves)
+    return (; zip(k_all, v_all)...)
+end
 
 end # module NamedTupleTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,3 +164,23 @@ nt1 = (a = 1, b = 2)
 c = 3
 nt = (a = 1, b = 2, c = 3)
 @test @namedtuple(nt1..., c) == nt
+
+
+@testset "Flattened NamedTuple" begin
+    nt = (x = 1, a = (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,))))
+    fnt = flattened(nt, :_)
+
+    @test getproperty(fnt, :x)   == 1
+    @test getproperty(fnt, :a)   == (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,)))
+    @test getproperty(fnt, :a_y) == 2
+    @test getproperty(fnt, :a_z) == 3
+    @test getproperty(fnt, :a_b) == ((a = 1,), (a = 2,), (a = 3,))
+    @test getproperty(fnt, :a_b_1) == (a = 1,)
+    @test getproperty(fnt, :a_b_2) == (a = 2,)
+    @test getproperty(fnt, :a_b_3) == (a = 3,)
+    @test getproperty(fnt, :a_b_1_a) == 1
+    @test getproperty(fnt, :a_b_2_a) == 2
+    @test getproperty(fnt, :a_b_3_a) == 3
+end
+
+


### PR DESCRIPTION
This PR adds a method `flattened`, which flattens a nested named tuple and preserves access to each value in the nested hierarchy. This method behaves as follows and passes the following test:

```julia
    nt = (x = 1, a = (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,))))
    fnt = flattened(nt, :_)

    @test getproperty(fnt, :x)   == 1
    @test getproperty(fnt, :a)   == (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,)))
    @test getproperty(fnt, :a_y) == 2
    @test getproperty(fnt, :a_z) == 3
    @test getproperty(fnt, :a_b) == ((a = 1,), (a = 2,), (a = 3,))
    @test getproperty(fnt, :a_b_1) == (a = 1,)
    @test getproperty(fnt, :a_b_2) == (a = 2,)
    @test getproperty(fnt, :a_b_3) == (a = 3,)
    @test getproperty(fnt, :a_b_1_a) == 1
    @test getproperty(fnt, :a_b_2_a) == 2
    @test getproperty(fnt, :a_b_3_a) == 3
```