### PR TITLE
fix ambiguity for empty namedtuple

### DIFF
--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -193,6 +193,7 @@ julia> ntAb3 = ntprototype("A", "b", 3)
 
 see: [`isprototype`](@ref)
 """
+namedtuple() = NamedTuple{()}
 namedtuple(::Tuple{}) = NamedTuple{()}
 namedtuple(names::NTuple{N,Symbol}) where {N} = NamedTuple{names}
 namedtuple(names::Vararg{Symbol}) = NamedTuple{names}

--- a/src/NamedTupleTools.jl
+++ b/src/NamedTupleTools.jl
@@ -193,6 +193,7 @@ julia> ntAb3 = ntprototype("A", "b", 3)
 
 see: [`isprototype`](@ref)
 """
+namedtuple(::Tuple{}) = NamedTuple{()}
 namedtuple(names::NTuple{N,Symbol}) where {N} = NamedTuple{names}
 namedtuple(names::Vararg{Symbol}) = NamedTuple{names}
 namedtuple(names::NTuple{N,String}) where {N}  = namedtuple(Symbol.(names))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ proto2 = prototype(nt2)
 @test select(nt1, nt2) == (a=1,b=2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
 @test select((a = 1, b = [1, 2]), (:b,)) == (b = [1, 2],)
+@test select(nt1, ()) == NamedTuple()
 
 @test split(nt1, :a)[1] == (a = 1,)
 @test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,7 @@ proto2 = prototype(nt2)
 @test select(nt1, nt2) == select(nt1, keys(nt2))
 @test select((a = 1, b = [1, 2]), (:b,)) == (b = [1, 2],)
 @test select(nt1, ()) == NamedTuple()
+@test select(nt1, Symbol[]) == NamedTuple()
 
 @test split(nt1, :a)[1] == (a = 1,)
 @test split(nt1, :a)[2] == (b = 2, c = 3, d = 4)


### PR DESCRIPTION
Current error is:

```julia
julia> select((x=1,), ())
ERROR: MethodError: namedtuple(::Tuple{}) is ambiguous. Candidates:
  namedtuple(names::Tuple{Vararg{Symbol, N}}) where N in NamedTupleTools at /global/homes/m/marius/.julia/packages/NamedTupleTools/GZxRn/src/NamedTupleTools.jl:196
  namedtuple(names::Tuple{Vararg{String, N}}) where N in NamedTupleTools at /global/homes/m/marius/.julia/packages/NamedTupleTools/GZxRn/src/NamedTupleTools.jl:198
Possible fix, define
  namedtuple(::Tuple{})
Stacktrace:
 [1] select(nt::NamedTuple{(:x,), Tuple{Int64}}, ks::Tuple{})
   @ NamedTupleTools ~/.julia/packages/NamedTupleTools/GZxRn/src/NamedTupleTools.jl:270
```